### PR TITLE
Add transform functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,8 @@
 
 ### 1.5.3
 - Kotlin 1.9.10
+
+### 1.5.4
+- Add `transform()` function to map results without nesting
+- Add `mapCatching()`
+- Implement `equals()` and `hashCode()`

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ kotlin.native.binary.freezing=disabled
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 1.5.3
+artifactVersion = 1.5.4

--- a/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -86,6 +86,27 @@ class KmmResult<T> private constructor(
         getOrNull()?.let { success(block(it)) } ?: this as KmmResult<R>
 
     /**
+     * Transforms this KmmResult into a KmmResult of different success type according to `block` and leaves the failure case untouched
+     * Avoids nested KmmResults
+     */
+    @Suppress("UNCHECKED_CAST")
+    inline fun <R> transform(block: (T) -> KmmResult<R>): KmmResult<R> =
+        getOrNull()?.let { block(it) } ?: this as KmmResult<R>
+
+
+    /**
+     * Returns the encapsulated result of the given [block] function applied to the encapsulated value
+     * if this instance represents [success][KmmResult.isSuccess] or the
+     * original encapsulated [Throwable] exception if it is [failure][KmmResult.isFailure].
+     *
+     * This function catches any [Throwable] exception thrown by [block] function and encapsulates it as a failure.
+     * See [map] for an alternative that rethrows exceptions from `transform` function.
+     */
+    @Suppress("UNCHECKED_CAST")
+    inline fun <R> mapCatching(block: (T) -> R): KmmResult<R> = unwrap().mapCatching { block(it) }.wrap()
+
+
+    /**
      * Transforms this KmmResult's failure-case according to `block` and leaves the success case untouched
      * (type erasure FTW!)
      */

--- a/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -86,13 +86,12 @@ class KmmResult<T> private constructor(
         getOrNull()?.let { success(block(it)) } ?: this as KmmResult<R>
 
     /**
-     * Transforms this KmmResult into a KmmResult of different success type according to `block` and leaves the failure case untouched
-     * Avoids nested KmmResults
+     * Transforms this KmmResult into a KmmResult of different success type according to `block` and leaves the
+     * failure case untouched. Avoids nested KmmResults
      */
     @Suppress("UNCHECKED_CAST")
     inline fun <R> transform(block: (T) -> KmmResult<R>): KmmResult<R> =
         getOrNull()?.let { block(it) } ?: this as KmmResult<R>
-
 
     /**
      * Returns the encapsulated result of the given [block] function applied to the encapsulated value
@@ -104,7 +103,6 @@ class KmmResult<T> private constructor(
      */
     @Suppress("UNCHECKED_CAST")
     inline fun <R> mapCatching(block: (T) -> R): KmmResult<R> = unwrap().mapCatching { block(it) }.wrap()
-
 
     /**
      * Transforms this KmmResult's failure-case according to `block` and leaves the success case untouched
@@ -153,6 +151,19 @@ class KmmResult<T> private constructor(
         val exName = exceptionOrNull()?.let { runCatching { it::class.simpleName }.getOrNull() }
         ".failure" + (exName?.let { "($it" }) + exceptionOrNull()?.let { err -> err.message?.let { "($it)" } ?: "" } +
             exName?.let { ")" }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as KmmResult<*>
+
+        return delegate == other.delegate
+    }
+
+    override fun hashCode(): Int {
+        return delegate.hashCode()
     }
 
     @OptIn(ExperimentalObjCRefinement::class)

--- a/src/commonTest/kotlin/KmmResultTest.kt
+++ b/src/commonTest/kotlin/KmmResultTest.kt
@@ -1,9 +1,11 @@
 package at.asitplus
 
+import at.asitplus.KmmResult.Companion.success
 import at.asitplus.KmmResult.Companion.wrap
 import kotlin.test.*
 
 class KmmResultTest {
+
     @Test
     fun testMap() {
         assertEquals("1234", KmmResult.success(1234).map { it.toString() }.getOrThrow())
@@ -13,6 +15,16 @@ class KmmResultTest {
         assertEquals(throwable, fail.map { it * 3 }.exceptionOrNull())
 
         assertEquals(9, KmmResult.success(3).map { it * 3 }.getOrThrow())
+    }
+
+    @Test
+    fun testTransform() {
+        val intResult = success(1234)
+        val stringResult = success("1234")
+        assertEquals(stringResult, intResult.transform { success(it.toString()) })
+        val throwable = NullPointerException("Null")
+        val fail: KmmResult<Int> = KmmResult.failure(throwable)
+        assertEquals(fail, fail.transform { success( it * 3 ) })
     }
 
     @Test


### PR DESCRIPTION
As title suggests adds small function that allows to transform a KmmResult of type T into a KmmResult of type R without needing to unpack it first.

Test Case fails although output is correct. Kotest bug?