### PR TITLE
Fixes & features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,8 @@
 
 ## 1.6.2
 - `wrapping` function, which wraps any exception as the specified type
+
+## Next
+- add `out` qualifier to KmmResult's type parameter
+- add `recoverCatching` to match Kotlin's `result`
+- add `callsInPlace` contracts

--- a/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -21,7 +21,7 @@ import kotlin.native.HiddenFromObjC
  * Relies on [Arrow](https://arrow-kt.io)'s
  * [nonFatalOrThrow](https://apidocs.arrow-kt.io/arrow-core/arrow.core/non-fatal-or-throw.html) internally.
  */
-class KmmResult<T>
+class KmmResult<out T>
 private constructor(
     private val delegate: Result<T>,
     @Suppress("UNUSED_PARAMETER") unusedButPreventsSignatureClashes: Boolean
@@ -81,7 +81,7 @@ private constructor(
      *
      * This function is a shorthand for `fold(onSuccess = { it }, onFailure = onFailure)` (see [fold]).
      */
-    inline fun getOrElse(onFailure: (exception: Throwable) -> T): T =
+    inline fun getOrElse(onFailure: (exception: Throwable) -> @UnsafeVariance T): T =
         if (isSuccess) getOrThrow() else onFailure(exceptionOrNull()!!)
 
     /**

--- a/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -219,6 +219,18 @@ private constructor(
 }
 
 /**
+ * If this is successful, returns it.
+ * If this is failed, encapsulate the result of the provided recovery function.
+ * If the recovery function throws, the return value is a failed KmmResult.
+ */
+inline fun <R, T:R> KmmResult<T>.recoverCatching(block: (error: Throwable) -> R): KmmResult<R> {
+    return when (val x = exceptionOrNull()) {
+        null -> this
+        else -> catching { block(x) }
+    }
+}
+
+/**
  * Non-fatal-only-catching version of stdlib's [runCatching], directly returning a [KmmResult] --
  * Re-throws any fatal exceptions, such as `OutOfMemoryError`. Relies on [Arrow](https://arrow-kt.io)'s
  * [nonFatalOrThrow](https://apidocs.arrow-kt.io/arrow-core/arrow.core/non-fatal-or-throw.html) internally.

--- a/src/commonTest/kotlin/KmmResultTest.kt
+++ b/src/commonTest/kotlin/KmmResultTest.kt
@@ -185,4 +185,35 @@ class KmmResultTest {
         )
 
     }
+
+    @Test
+    fun testNullability() {
+        val result = KmmResult.success<Unit?>(null)
+        assertNull(result.getOrThrow())
+        assertTrue(result.isSuccess)
+        assertFalse(result.isFailure)
+
+        fun assertCalled(block: ((Unit?)->Unit)->Unit) {
+            var hit = false
+            block { assertNull(it); hit = true }
+            if (hit) asserter.fail("Expected function was not called")
+        }
+
+        fun assertUnreachable(): Nothing {
+            asserter.fail("Unreachable code is reachable")
+        }
+
+        assertCalled { fn -> result.onSuccess(fn) }
+
+        assertCalled { fn ->
+            result.fold(
+                onSuccess = fn,
+                onFailure = { assertUnreachable() }
+            )
+        }
+
+        assertCalled { fn ->
+            result.transform { catching { fn(it) }}
+        }
+    }
 }

--- a/src/commonTest/kotlin/KmmResultTest.kt
+++ b/src/commonTest/kotlin/KmmResultTest.kt
@@ -196,7 +196,7 @@ class KmmResultTest {
         fun assertCalled(block: ((Unit?)->Unit)->Unit) {
             var hit = false
             block { assertNull(it); hit = true }
-            if (hit) asserter.fail("Expected function was not called")
+            if (!hit) asserter.fail("Expected function was not called")
         }
 
         fun assertUnreachable(): Nothing {


### PR DESCRIPTION
- Fix internal `getOrNull()` misuses; `getOrNull() == null` does not imply failure, the contained type might be nullable!
- Add `out` qualifier to `T`; `KmmResult<Super>` is a superclass of `KmmResult<Sub>`
- Add missing `recoverCatching` function that Kotlin's `Result` has
- Add `callsInPlace` contracts to everything