### PR TITLE
Adjust return type of `KmmResult.failure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,5 @@
 - Deprecate `map` in favor of `mapCatching`
 - Add safeguards to `mapCatching` to prevent `Unit` auto-deduction
 - Add some additional test shorthands
+- Change `KmmResult.failure` to return `KmmResult<Nothing>`, removing the type argument
+  - A version taking an explicit type argument still exists but is deprecated

--- a/kmmresult/api/android/kmmresult.api
+++ b/kmmresult/api/android/kmmresult.api
@@ -21,12 +21,14 @@ public final class at/asitplus/KmmResult {
 	public static final fun success (Ljava/lang/Object;)Lat/asitplus/KmmResult;
 	public fun toString ()Ljava/lang/String;
 	public final fun transform (Lkotlin/jvm/functions/Function1;)Lat/asitplus/KmmResult;
+	public static final synthetic fun typedFailure (Ljava/lang/Throwable;)Lat/asitplus/KmmResult;
 	public final fun unwrap-d1pmJ48 ()Ljava/lang/Object;
 }
 
 public final class at/asitplus/KmmResult$Companion {
 	public final fun failure (Ljava/lang/Throwable;)Lat/asitplus/KmmResult;
 	public final fun success (Ljava/lang/Object;)Lat/asitplus/KmmResult;
+	public final synthetic fun typedFailure (Ljava/lang/Throwable;)Lat/asitplus/KmmResult;
 	public final fun wrap (Ljava/lang/Object;)Lat/asitplus/KmmResult;
 }
 

--- a/kmmresult/api/jvm/kmmresult.api
+++ b/kmmresult/api/jvm/kmmresult.api
@@ -21,12 +21,14 @@ public final class at/asitplus/KmmResult {
 	public static final fun success (Ljava/lang/Object;)Lat/asitplus/KmmResult;
 	public fun toString ()Ljava/lang/String;
 	public final fun transform (Lkotlin/jvm/functions/Function1;)Lat/asitplus/KmmResult;
+	public static final synthetic fun typedFailure (Ljava/lang/Throwable;)Lat/asitplus/KmmResult;
 	public final fun unwrap-d1pmJ48 ()Ljava/lang/Object;
 }
 
 public final class at/asitplus/KmmResult$Companion {
 	public final fun failure (Ljava/lang/Throwable;)Lat/asitplus/KmmResult;
 	public final fun success (Ljava/lang/Object;)Lat/asitplus/KmmResult;
+	public final synthetic fun typedFailure (Ljava/lang/Throwable;)Lat/asitplus/KmmResult;
 	public final fun wrap (Ljava/lang/Object;)Lat/asitplus/KmmResult;
 }
 

--- a/kmmresult/api/kmmresult.klib.api
+++ b/kmmresult/api/kmmresult.klib.api
@@ -35,6 +35,7 @@ final class <#A: out kotlin/Any?> at.asitplus/KmmResult { // at.asitplus/KmmResu
         final fun <#A2: kotlin/Any?> (kotlin/Result<#A2>).wrap(): at.asitplus/KmmResult<#A2> // at.asitplus/KmmResult.Companion.wrap|wrap@kotlin.Result<0:0>(){0§<kotlin.Any?>}[0]
         final fun <#A2: kotlin/Any?> failure(kotlin/Throwable): at.asitplus/KmmResult<#A2> // at.asitplus/KmmResult.Companion.failure|failure(kotlin.Throwable){0§<kotlin.Any?>}[0]
         final fun <#A2: kotlin/Any?> success(#A2): at.asitplus/KmmResult<#A2> // at.asitplus/KmmResult.Companion.success|success(0:0){0§<kotlin.Any?>}[0]
+        final fun failure(kotlin/Throwable): at.asitplus/KmmResult<kotlin/Nothing> // at.asitplus/KmmResult.Companion.failure|failure(kotlin.Throwable){}[0]
     }
 }
 

--- a/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -11,7 +11,9 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.experimental.ExperimentalObjCName
 import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
 import kotlin.native.HiddenFromObjC
 import kotlin.native.ObjCName
 
@@ -248,6 +250,13 @@ private constructor(
         @HiddenFromObjC
         @JvmStatic
         fun failure(error: Throwable): KmmResult<Nothing> = KmmResult(error)
+
+        @HiddenFromObjC
+        @JvmStatic
+        @JvmName("typedFailure")
+        @JvmSynthetic
+        @Deprecated("Superfluous type argument", ReplaceWith("failure(error)"))
+        fun <T> failure(error: Throwable): KmmResult<T> = failure(error)
 
         /**
          * Returns a [KmmResult] equivalent of this Result

--- a/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -247,7 +247,7 @@ private constructor(
 
         @HiddenFromObjC
         @JvmStatic
-        fun <T> failure(error: Throwable): KmmResult<T> = KmmResult(error)
+        fun failure(error: Throwable): KmmResult<Nothing> = KmmResult(error)
 
         /**
          * Returns a [KmmResult] equivalent of this Result

--- a/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
+++ b/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
@@ -260,4 +260,10 @@ class KmmResultTest {
         )
 
     }
+
+    @Test
+    fun testTypedFailure() {
+        val x = Throwable("foobar")
+        assertEquals(KmmResult.failure(x), KmmResult.failure<Int>(x))
+    }
 }

--- a/kmmresult/src/jvmTest/java/KmmResultTestJvm.kt
+++ b/kmmresult/src/jvmTest/java/KmmResultTestJvm.kt
@@ -1,11 +1,15 @@
 import io.kotest.assertions.asClue
-import io.kotest.matchers.compilation.CompileConfig
 import io.kotest.matchers.compilation.codeSnippet
 import io.kotest.matchers.compilation.shouldCompile
-import io.kotest.matchers.compilation.shouldNotCompile
 import kotlin.test.Test
 
 class KmmResultTestJvm {
+    @Test
+    fun deprecatedFailureOverloadShouldBeUnambiguous() {
+        codeSnippet("val v: at.asitplus.KmmResult<Int> = at.asitplus.KmmResult.failure(Throwable())")
+            .shouldCompile()
+    }
+
     @Test
     fun catchPathologicalUnitBehavior() {
         // mapCatching lambda arguments should not be automatically coerced to Unit, regardless of the specified return type


### PR DESCRIPTION
Return `KmmResult<Nothing>` from `KmmResult.failure`. Due to the `out` variance on `KmmResult`, this is a subtype of any `KmmResult<T>`.