### PR TITLE
Release/1.9.3

### DIFF
--- a/.github/workflows/build-jvm.yml
+++ b/.github/workflows/build-jvm.yml
@@ -1,4 +1,4 @@
-name: Build JVM/JS/iOS/macOS/tvOS/MinGW/wasmJS/wasmWasi/Linux
+name: Build all Targets
 on: [push]
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,4 +74,17 @@
 - Simplify build and add BCV thanks to @Goooler
 - lower Android `minSdk` to 21 (5.0 Lollipop)
 
+## 1.9.3
+- Kotlin 2.1.20
+- Add more targets:
+  * watchosSimulatorArm64
+  * watchosX64
+  * watchosArm32
+  * watchosArm64
+  * watchosDeviceArm64
+  * androidNativeX64
+  * androidNativeX86
+  * androidNativeArm32
+  * androidNativeArm64
+
 ## NEXT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,3 +73,5 @@
 ## 1.9.2
 - Simplify build and add BCV thanks to @Goooler
 - lower Android `minSdk` to 21 (5.0 Lollipop)
+
+## NEXT

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wrapper for `kotlin.Result` with KMM goodness, s.t. it becomes possible to expos
 public APIs interfacing with platform-specific code. For Kotlin/Native (read: iOS), this requires a `Result` equivalent, which
 is *not* a value class (a sealed `Either` type also does not interop well with Swift). 
 
-`KmmResult` comes to the rescue! → [Full documentation](https://a-sit-plus.github.io/KmmResult/).
+`KmmResult` comes to the rescue on *all* KMP targets! → [Full documentation](https://a-sit-plus.github.io/KmmResult/).
 
 ## Using in your Projects
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.kotlin.dsl.support.listFilesOrdered
 
 plugins {
-    kotlin("multiplatform") version "2.1.0" apply false
+    kotlin("multiplatform") version "2.1.20" apply false
     id("com.android.library") version "8.2.2" apply false
     id("org.jetbrains.dokka") version "2.0.0"
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 1.9.2
+artifactVersion = 1.9.3-SNAPSHOT
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 android.experimental.lint.version=8.5.0
 android.lint.useK2Uast=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 1.9.3-SNAPSHOT
+artifactVersion = 1.9.3
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 android.experimental.lint.version=8.5.0
 android.lint.useK2Uast=true

--- a/kmmresult-test/api/kmmresult-test.klib.api
+++ b/kmmresult-test/api/kmmresult-test.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs]
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/kmmresult-test/build.gradle.kts
+++ b/kmmresult-test/build.gradle.kts
@@ -69,12 +69,21 @@ kotlin {
 
     macosArm64()
     macosX64()
-    tvosArm64()
-    tvosX64()
-    tvosSimulatorArm64()
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    watchosDeviceArm64()
+    androidNativeX64()
+    androidNativeX86()
+    androidNativeArm32()
+    androidNativeArm64()
 
 
     jvm {

--- a/kmmresult/api/kmmresult.klib.api
+++ b/kmmresult/api/kmmresult.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi]
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/kmmresult/build.gradle.kts
+++ b/kmmresult/build.gradle.kts
@@ -78,7 +78,12 @@ kotlin {
         tvosSimulatorArm64(),
         iosX64(),
         iosArm64(),
-        iosSimulatorArm64()
+        iosSimulatorArm64(),
+        watchosSimulatorArm64(),
+        watchosX64(),
+        watchosArm32(),
+        watchosArm64(),
+        watchosDeviceArm64(),
     ).forEach {
         it.binaries.framework {
             baseName = "KmmResult"
@@ -88,6 +93,10 @@ kotlin {
         }
     }
 
+    androidNativeX64()
+    androidNativeX86()
+    androidNativeArm32()
+    androidNativeArm64()
     androidTarget {
         compilerOptions {
             publishLibraryVariants("release")
@@ -98,7 +107,7 @@ kotlin {
     jvm {
         compilations.all {
             kotlinOptions {
-                jvmTarget = "11"
+                jvmTarget = "17"
                 freeCompilerArgs = listOf(
                     "-Xjsr305=strict"
                 )
@@ -127,7 +136,12 @@ kotlin {
             implementation(kotlin("test"))
         }
     }
-    sourceSets.filterNot { it.name.startsWith("common") || it.name.startsWith("jvm")|| it.name.startsWith("android") }
+
+    sourceSets.filter { it.name.startsWith("androidNative") && it.name.endsWith("Main") }.forEach { srcSet ->
+        srcSet.kotlin.srcDir("$projectDir/src/nonJvmMain/kotlin")
+    }
+
+    sourceSets.filterNot { it.name.startsWith("common") || it.name.startsWith("jvm") || it.name.startsWith("android") }
         .filter { it.name.endsWith("Main") }.forEach { srcSet ->
             srcSet.kotlin.srcDir("$projectDir/src/nonJvmMain/kotlin")
         }


### PR DESCRIPTION
## 1.9.3
- Kotlin 2.1.20
- Add more targets:
  * watchosSimulatorArm64
  * watchosX64
  * watchosArm32
  * watchosArm64
  * watchosDeviceArm64
  * androidNativeX64
  * androidNativeX86
  * androidNativeArm32
  * androidNativeArm64
