### PR TITLE
Add Unit data object to replace kotlin's Unit in KmmResult<Unit>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,3 +88,4 @@
   * androidNativeArm64
 
 ## NEXT
+- Add KmmResult.Unit data object to use in place of kotlin's Unit in KmmResult

--- a/kmmresult/api/android/kmmresult.api
+++ b/kmmresult/api/android/kmmresult.api
@@ -30,6 +30,13 @@ public final class at/asitplus/KmmResult$Companion {
 	public final fun wrap (Ljava/lang/Object;)Lat/asitplus/KmmResult;
 }
 
+public final class at/asitplus/KmmResult$Unit {
+	public static final field INSTANCE Lat/asitplus/KmmResult$Unit;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class at/asitplus/KmmResultKt {
 	public static final fun recoverCatching (Lat/asitplus/KmmResult;Lkotlin/jvm/functions/Function1;)Lat/asitplus/KmmResult;
 }

--- a/kmmresult/api/jvm/kmmresult.api
+++ b/kmmresult/api/jvm/kmmresult.api
@@ -30,6 +30,13 @@ public final class at/asitplus/KmmResult$Companion {
 	public final fun wrap (Ljava/lang/Object;)Lat/asitplus/KmmResult;
 }
 
+public final class at/asitplus/KmmResult$Unit {
+	public static final field INSTANCE Lat/asitplus/KmmResult$Unit;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class at/asitplus/KmmResultKt {
 	public static final fun recoverCatching (Lat/asitplus/KmmResult;Lkotlin/jvm/functions/Function1;)Lat/asitplus/KmmResult;
 }

--- a/kmmresult/api/kmmresult.klib.api
+++ b/kmmresult/api/kmmresult.klib.api
@@ -36,6 +36,12 @@ final class <#A: out kotlin/Any?> at.asitplus/KmmResult { // at.asitplus/KmmResu
         final fun <#A2: kotlin/Any?> failure(kotlin/Throwable): at.asitplus/KmmResult<#A2> // at.asitplus/KmmResult.Companion.failure|failure(kotlin.Throwable){0§<kotlin.Any?>}[0]
         final fun <#A2: kotlin/Any?> success(#A2): at.asitplus/KmmResult<#A2> // at.asitplus/KmmResult.Companion.success|success(0:0){0§<kotlin.Any?>}[0]
     }
+
+    final object Unit { // at.asitplus/KmmResult.Unit|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // at.asitplus/KmmResult.Unit.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // at.asitplus/KmmResult.Unit.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // at.asitplus/KmmResult.Unit.toString|toString(){}[0]
+    }
 }
 
 final inline fun (kotlin/Throwable).at.asitplus/nonFatalOrThrow(): kotlin/Throwable // at.asitplus/nonFatalOrThrow|nonFatalOrThrow@kotlin.Throwable(){}[0]

--- a/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -231,6 +231,13 @@ private constructor(
     override fun hashCode(): Int {
         return delegate.hashCode()
     }
+    /**
+     * Success marker used in place of Kotlin's `Unit` for `KmmResult`.
+     *
+     * `KmmResult<Unit>` can succeed when `map` is used instead of `transform`, since
+     * nested results are silently dropped. See test case for example of this
+     */
+    data object Unit
 
     @OptIn(ExperimentalObjCRefinement::class)
     companion object {

--- a/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -231,6 +231,7 @@ private constructor(
     override fun hashCode(): Int {
         return delegate.hashCode()
     }
+
     /**
      * Success marker used in place of Kotlin's `Unit` for `KmmResult`.
      *

--- a/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
+++ b/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
@@ -292,6 +292,16 @@ class KmmResultTest {
             returnFails.isSuccess
         }
 
+        assertTrue("Exception is swallowed by .mapCatching") {
+            val returnFails: KmmResult<Unit> = resultReturnerWrapped.mapCatching { it.returnUnitResult() }
+            returnFails.isSuccess
+        }
+
+        assertTrue("Exception is not swallowed by .transform") {
+            val returnFails: KmmResult<Unit> = resultReturnerWrapped.transform { it.returnUnitResult() }
+            returnFails.isFailure
+        }
+
         assertFails("Compiler does not allow the same syntax for KmmResult.Unit!") {
             val returnFails: KmmResult<KmmResult.Unit> = resultReturnerWrapped.map { it.returnKmmResultUnitResult().getOrThrow() }
             returnFails.isFailure

--- a/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
+++ b/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
@@ -51,7 +51,7 @@ class KmmResultTest {
         assertEquals(stringResult, intResult.transform { success(it.toString()) })
         val throwable = NullPointerException("Null")
         val fail: KmmResult<Int> = KmmResult.failure(throwable)
-        assertEquals(fail, fail.transform { success( it * 3 ) })
+        assertEquals(fail, fail.transform { success(it * 3) })
     }
 
     @Test
@@ -66,7 +66,6 @@ class KmmResultTest {
         val success = KmmResult.success(3)
         assertEquals(success, success.mapFailure { it })
     }
-
 
 
     @Test
@@ -170,7 +169,7 @@ class KmmResultTest {
         assertTrue(result.isSuccess)
         assertFalse(result.isFailure)
 
-        fun assertCalled(block: ((Unit?)->Unit)->Unit) {
+        fun assertCalled(block: ((Unit?) -> Unit) -> Unit) {
             var hit = false
             block { assertNull(it); hit = true }
             if (!hit) asserter.fail("Expected function was not called")
@@ -190,7 +189,7 @@ class KmmResultTest {
         }
 
         assertCalled { fn ->
-            result.transform { catching { fn(it) }}
+            result.transform { catching { fn(it) } }
         }
     }
 
@@ -222,11 +221,12 @@ class KmmResultTest {
 
     @Test
     fun testCatchingAs() {
-        class TestException(val usedTwoArgCtor: Boolean): Throwable() {
+        class TestException(val usedTwoArgCtor: Boolean) : Throwable() {
             @Suppress("UNUSED")
-            constructor(a:String?,b:Throwable?): this(true)
+            constructor(a: String?, b: Throwable?) : this(true)
+
             @Suppress("UNUSED")
-            constructor(b:Throwable?): this(false)
+            constructor(b: Throwable?) : this(false)
         }
         assertIs<TestException>(
             catchingUnwrappedAs(a = ::TestException) {
@@ -259,5 +259,49 @@ class KmmResultTest {
             }.exceptionOrNull()
         )
 
+    }
+
+    @Test
+    fun testKmmResultNull() {
+
+        //If init succeeds always throws on return and vice versa
+        class FragileResultReturner(val initSuccessful: Boolean) {
+            init {
+                if (!initSuccessful) throw Exception()
+            }
+
+            fun returnUnitResult() = if (initSuccessful) runCatching { require(false) }.wrap() else success(Unit)
+            fun returnKmmResultUnitResult(): KmmResult<KmmResult.Unit> = if (initSuccessful) runCatching {
+                require(false)
+                KmmResult.Unit
+            }.wrap() else success(
+                KmmResult.Unit
+            )
+        }
+
+        fun getSuccessReturner(succeeds: Boolean): KmmResult<FragileResultReturner> =
+            runCatching { FragileResultReturner(succeeds) }.wrap()
+
+        val resultReturnerWrapped = getSuccessReturner(true)
+
+        assertTrue("Result returner can be initialized") {
+            resultReturnerWrapped.isSuccess
+        }
+
+        assertTrue("Result returner always returns throwable") {
+            val returner = resultReturnerWrapped.getOrThrow()
+            returner.returnUnitResult().isFailure
+            returner.returnKmmResultUnitResult().isFailure
+        }
+
+        assertTrue("Exception is swallowed by .map") {
+            val returnFails: KmmResult<Unit> = resultReturnerWrapped.map { it.returnUnitResult() }
+            returnFails.isSuccess
+        }
+
+        assertFails("Compiler does not allow the same syntax for KmmResult.Unit!") {
+            val returnFails: KmmResult<KmmResult.Unit> = resultReturnerWrapped.map { it.returnKmmResultUnitResult().getOrThrow() }
+            returnFails.isFailure
+        }
     }
 }

--- a/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
+++ b/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
@@ -264,25 +264,18 @@ class KmmResultTest {
     @Test
     fun testKmmResultNull() {
 
-        //If init succeeds always throws on return and vice versa
-        class FragileResultReturner(val initSuccessful: Boolean) {
-            init {
-                if (!initSuccessful) throw Exception()
-            }
-
-            fun returnUnitResult() = if (initSuccessful) runCatching { require(false) }.wrap() else success(Unit)
-            fun returnKmmResultUnitResult(): KmmResult<KmmResult.Unit> = if (initSuccessful) runCatching {
+        class FailureReturner {
+            fun returnUnitResult() = runCatching { require(false) }.wrap()
+            fun returnKmmResultUnitResult(): KmmResult<KmmResult.Unit> = runCatching {
                 require(false)
                 KmmResult.Unit
-            }.wrap() else success(
-                KmmResult.Unit
-            )
+            }.wrap()
         }
 
-        fun getSuccessReturner(succeeds: Boolean): KmmResult<FragileResultReturner> =
-            runCatching { FragileResultReturner(succeeds) }.wrap()
+        fun getWrappedFailureReturner(): KmmResult<FailureReturner> =
+            runCatching { FailureReturner() }.wrap()
 
-        val resultReturnerWrapped = getSuccessReturner(true)
+        val resultReturnerWrapped = getWrappedFailureReturner()
 
         assertTrue("Result returner can be initialized") {
             resultReturnerWrapped.isSuccess

--- a/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
+++ b/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
@@ -292,9 +292,19 @@ class KmmResultTest {
             returnFails.isSuccess
         }
 
-        assertTrue("Exception is swallowed by .mapCatching") {
+        assertTrue("Exception is swallowed by .mapCatching by erroneous casting") {
             val returnFails: KmmResult<Unit> = resultReturnerWrapped.mapCatching { it.returnUnitResult() }
             returnFails.isSuccess
+        }
+
+        assertTrue("Exception is not swallowed by .mapCatching when correctly nesting") {
+            val returnFails: KmmResult<KmmResult<Unit>> = resultReturnerWrapped.mapCatching { it.returnUnitResult() }
+            returnFails.getOrThrow().isFailure
+        }
+
+        assertTrue("Exception is not swallowed by .mapCatching when eliminating nesting") {
+            val returnFails: KmmResult<Unit> = resultReturnerWrapped.mapCatching { it.returnUnitResult().getOrThrow() }
+            returnFails.isFailure
         }
 
         assertTrue("Exception is not swallowed by .transform") {


### PR DESCRIPTION
Introduces generic `KmmResult.Unit` data object to be used instead of `Unit` in KmmResults inspired by Signums `Verifier.Success` object which it replaces.
This class is necessary because situations where descriptive errors need to be returned but no value in case of success. This comes up quite often (every verify/validate function basically)  and it is odd to reference `Verifier.Success` from an entirely different repository (like VCK)

Also includes a test case which documents the swallowing of an exception and why this workaround fixes the problem.

We should probably look for a way to disable `KmmResult<Unit>` in general.