### PR TITLE
Add Test case that documents pathological behavior

### DIFF
--- a/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
+++ b/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
@@ -260,4 +260,48 @@ class KmmResultTest {
         )
 
     }
+
+    @Test
+    fun testKmmResultNull() {
+
+        class FailureReturner {
+            fun returnKmmFailure(): KmmResult<Unit> = runCatching { require(false) }.wrap()
+        }
+
+        fun getWrappedFailureReturner(): KmmResult<FailureReturner> =
+            runCatching { FailureReturner() }.wrap()
+
+        val resultReturnerWrapped = getWrappedFailureReturner()
+
+        assertTrue("Result returner can be initialized") {
+            resultReturnerWrapped.isSuccess
+        }
+
+        assertTrue("Result returner always returns throwable") {
+            val returner = resultReturnerWrapped.getOrThrow()
+            returner.returnKmmFailure().isFailure
+        }
+
+        //This simply shouldnt compile
+        assertTrue("Exception is not swallowed by .mapCatching by erroneous casting") {
+            val returnFails: KmmResult<Unit> = resultReturnerWrapped.mapCatching { it.returnKmmFailure() }
+            returnFails.isFailure
+        }
+
+        assertTrue("Exception is not swallowed by .mapCatching when correctly nesting") {
+            val returnFails: KmmResult<KmmResult<Unit>> = resultReturnerWrapped.mapCatching { it.returnKmmFailure() }
+            returnFails.getOrThrow().isFailure
+        }
+
+        assertTrue("Exception is not swallowed by .mapCatching when eliminating nesting") {
+            val returnFails: KmmResult<Unit> = resultReturnerWrapped.mapCatching { it.returnKmmFailure().getOrThrow() }
+            returnFails.isFailure
+        }
+
+        assertTrue("Exception is not swallowed by .transform") {
+            val returnFails: KmmResult<Unit> = resultReturnerWrapped.transform { it.returnKmmFailure() }
+            returnFails.isFailure
+        }
+    }
+
 }


### PR DESCRIPTION
Type Inference for KmmResult<Unit> is still a problem even after 
https://youtrack.jetbrains.com/issue/KT-82863/NoInfer-regression-from-Kotlin-2.1-to-Kotlin-2.2
was fixed. 

This test case documents how to trigger the problem(copied from #22) so that it can be pointed to for reference in other PRs and also if it is ever fixed to check for regressions. 

Cannot be merged like this because now tests obviously fail. Looking for feedback on how to best implement this