### PR TITLE
Move `getOrElse` to an extension function (and make it more permissive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,3 +94,4 @@
 - Add some additional test shorthands
 - Change `KmmResult.failure` to return `KmmResult<Nothing>`, removing the type argument
   - A version taking an explicit type argument still exists but is deprecated
+- Move `getOrElse` into an extension method and make it more permissive

--- a/kmmresult/api/android/kmmresult.api
+++ b/kmmresult/api/android/kmmresult.api
@@ -33,6 +33,7 @@ public final class at/asitplus/KmmResult$Companion {
 }
 
 public final class at/asitplus/KmmResultKt {
+	public static final fun getOrElse (Lat/asitplus/KmmResult;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun recoverCatching (Lat/asitplus/KmmResult;Lkotlin/jvm/functions/Function1;)Lat/asitplus/KmmResult;
 }
 

--- a/kmmresult/api/jvm/kmmresult.api
+++ b/kmmresult/api/jvm/kmmresult.api
@@ -33,6 +33,7 @@ public final class at/asitplus/KmmResult$Companion {
 }
 
 public final class at/asitplus/KmmResultKt {
+	public static final fun getOrElse (Lat/asitplus/KmmResult;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun recoverCatching (Lat/asitplus/KmmResult;Lkotlin/jvm/functions/Function1;)Lat/asitplus/KmmResult;
 }
 

--- a/kmmresult/api/kmmresult.klib.api
+++ b/kmmresult/api/kmmresult.klib.api
@@ -40,6 +40,7 @@ final class <#A: out kotlin/Any?> at.asitplus/KmmResult { // at.asitplus/KmmResu
 }
 
 final inline fun (kotlin/Throwable).at.asitplus/nonFatalOrThrow(): kotlin/Throwable // at.asitplus/nonFatalOrThrow|nonFatalOrThrow@kotlin.Throwable(){}[0]
+final inline fun <#A: kotlin/Any?, #B: #A> (at.asitplus/KmmResult<#B>).at.asitplus/getOrElse(kotlin/Function1<kotlin/Throwable, #A>): #A // at.asitplus/getOrElse|getOrElse@at.asitplus.KmmResult<0:1>(kotlin.Function1<kotlin.Throwable,0:0>){0§<kotlin.Any?>;1§<0:0>}[0]
 final inline fun <#A: kotlin/Any?, #B: #A> (at.asitplus/KmmResult<#B>).at.asitplus/recoverCatching(kotlin/Function1<kotlin/Throwable, #A>): at.asitplus/KmmResult<#A> // at.asitplus/recoverCatching|recoverCatching@at.asitplus.KmmResult<0:1>(kotlin.Function1<kotlin.Throwable,0:0>){0§<kotlin.Any?>;1§<0:0>}[0]
 final inline fun <#A: kotlin/Any?, #B: kotlin/Any?> (#A).at.asitplus/catchingUnwrapped(kotlin/Function1<#A, #B>): kotlin/Result<#B> // at.asitplus/catchingUnwrapped|catchingUnwrapped@0:0(kotlin.Function1<0:0,0:1>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 final inline fun <#A: kotlin/Any?, #B: kotlin/Any?> (#B).at.asitplus/catching(kotlin/Function1<#B, #A>): at.asitplus/KmmResult<#A> // at.asitplus/catching|catching@0:1(kotlin.Function1<0:1,0:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]

--- a/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -82,17 +82,6 @@ private constructor(
     val isFailure: Boolean get() = delegate.isFailure
 
     /**
-     * Returns the encapsulated value if this instance represents [success][isSuccess] or the
-     * result of [onFailure] function for the encapsulated [Throwable] exception if it is [failure][isFailure].
-     *
-     * Note, that this function rethrows any [Throwable] exception thrown by [onFailure] function.
-     *
-     * This function is a shorthand for `fold(onSuccess = { it }, onFailure = onFailure)` (see [fold]).
-     */
-    inline fun getOrElse(onFailure: (exception: Throwable) -> @UnsafeVariance T): T =
-        if (isSuccess) getOrThrow() else onFailure(exceptionOrNull()!!)
-
-    /**
      * Returns the encapsulated [Throwable] exception if this instance represents [failure][isFailure] or `null`
      * if it is [success][isSuccess].
      *
@@ -191,7 +180,7 @@ private constructor(
     }
 
     /**
-     * singular version of `fold`'s `onSuccess`
+     * singular version of `fold`'s `onSuccess`, returning `this`
      */
     inline fun <R> onSuccess(block: (value: T) -> R): KmmResult<T> {
         contract {
@@ -202,7 +191,7 @@ private constructor(
     }
 
     /**
-     * singular version of `fold`'s `onFailure`
+     * singular version of `fold`'s `onFailure`, returning `this`
      */
     inline fun <R> onFailure(block: (error: Throwable) -> R): KmmResult<T> {
         contract {
@@ -264,6 +253,17 @@ private constructor(
         fun <T> Result<T>.wrap(): KmmResult<T> = KmmResult(this, false)
     }
 }
+
+/**
+ * Returns the encapsulated value if this instance represents [success][isSuccess] or the
+ * result of [onFailure] function for the encapsulated [Throwable] exception if it is [failure][isFailure].
+ *
+ * Note, that this function rethrows any [Throwable] exception thrown by [onFailure] function.
+ *
+ * This function is a shorthand for `fold(onSuccess = { it }, onFailure = onFailure)` (see [fold]).
+ */
+inline fun <S, T : S> KmmResult<T>.getOrElse(onFailure: (exception: Throwable) -> S): S =
+    if (isSuccess) getOrThrow() else onFailure(exceptionOrNull()!!)
 
 /**
  * If this is successful, returns it.

--- a/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -81,6 +81,12 @@ private constructor(
      */
     val isFailure: Boolean get() = delegate.isFailure
 
+    /** See [getOrElse] */
+    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+    @kotlin.internal.LowPriorityInOverloadResolution
+    @Deprecated("HIDDEN")
+    inline fun getOrElse(onFailure: (exception: Throwable) -> @UnsafeVariance T): T = getOrElse(onFailure)
+
     /**
      * Returns the encapsulated [Throwable] exception if this instance represents [failure][isFailure] or `null`
      * if it is [success][isSuccess].

--- a/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
+++ b/kmmresult/src/commonMain/kotlin/at/asitplus/KmmResult.kt
@@ -81,7 +81,7 @@ private constructor(
      */
     val isFailure: Boolean get() = delegate.isFailure
 
-    /** See [getOrElse] */
+    /** See the getOrElse extension function */
     @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
     @kotlin.internal.LowPriorityInOverloadResolution
     @Deprecated("HIDDEN")
@@ -261,15 +261,22 @@ private constructor(
 }
 
 /**
- * Returns the encapsulated value if this instance represents [success][isSuccess] or the
- * result of [onFailure] function for the encapsulated [Throwable] exception if it is [failure][isFailure].
+ * Returns the encapsulated value if this instance represents [success][KmmResult.isSuccess] or the
+ * result of [onFailure] function for the encapsulated [Throwable] exception if it is [failure][KmmResult.isFailure].
  *
  * Note, that this function rethrows any [Throwable] exception thrown by [onFailure] function.
  *
  * This function is a shorthand for `fold(onSuccess = { it }, onFailure = onFailure)` (see [fold]).
  */
-inline fun <S, T : S> KmmResult<T>.getOrElse(onFailure: (exception: Throwable) -> S): S =
-    if (isSuccess) getOrThrow() else onFailure(exceptionOrNull()!!)
+inline fun <S, T : S> KmmResult<T>.getOrElse(onFailure: (exception: Throwable) -> S): S {
+    contract {
+        callsInPlace(onFailure, InvocationKind.AT_MOST_ONCE)
+    }
+    return when (val x = exceptionOrNull()) {
+        null -> getOrThrow()
+        else -> onFailure(x)
+    }
+}
 
 /**
  * If this is successful, returns it.

--- a/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
+++ b/kmmresult/src/commonTest/kotlin/KmmResultTest.kt
@@ -18,7 +18,7 @@ class KmmResultTest {
         }
 
         assertFailsWith(CancellationException::class) {
-            KmmResult.failure<Unit>(CancellationException("just a test", null))
+            KmmResult.failure(CancellationException("just a test", null))
         }
         assertFailsWith(CancellationException::class) {
             Result.failure<Unit>(CancellationException("just a test", null)).wrap()
@@ -28,7 +28,7 @@ class KmmResultTest {
         Result.failure<Unit>(CancellationException("just a test", null))
         catching { throw NullPointerException("just a test") }
         runCatching { throw NullPointerException("just a test") }.wrap()
-        KmmResult.failure<Unit>(NullPointerException("just a test"))
+        KmmResult.failure(NullPointerException("just a test"))
         Result.failure<Unit>(NullPointerException("just a test")).wrap()
 
     }
@@ -57,7 +57,7 @@ class KmmResultTest {
     @Test
     fun testMapFailure() {
         assertTrue(
-            KmmResult.failure<Int>(NullPointerException()).mapFailure {
+            KmmResult.failure(NullPointerException()).mapFailure {
                 assertTrue(it is NullPointerException)
                 IllegalStateException(it)
             }.exceptionOrNull() is IllegalStateException,
@@ -87,20 +87,20 @@ class KmmResultTest {
     fun testGetOrElse() {
         val result: KmmResult<Int> = runCatching { throw NullPointerException("NULL") }.wrap()
         assertEquals(3, result.getOrElse { 3 })
-        assertEquals(9, (KmmResult.failure<Int>(NullPointerException("NULL"))).getOrElse { 9 })
+        assertEquals(9, (KmmResult.failure(NullPointerException("NULL"))).getOrElse { 9 })
         assertEquals(3, KmmResult.success(3).getOrElse { 9 })
     }
 
     @Test
     fun testGetOrNull() {
-        assertNull(KmmResult.failure<Int>(NullPointerException()).getOrNull())
+        assertNull(KmmResult.failure(NullPointerException()).getOrNull())
         assertEquals(3, KmmResult.success(3).getOrNull())
     }
 
     @Test
     fun testIsFailure() {
-        assertTrue(KmmResult.failure<Int>(NullPointerException()).isFailure)
-        assertFalse(KmmResult.failure<Int>(NullPointerException()).isSuccess)
+        assertTrue(KmmResult.failure(NullPointerException()).isFailure)
+        assertFalse(KmmResult.failure(NullPointerException()).isSuccess)
     }
 
     @Test
@@ -120,7 +120,7 @@ class KmmResultTest {
         )
         assertEquals(
             9,
-            KmmResult.failure<Int>(IllegalStateException()).fold(
+            (KmmResult.failure(IllegalStateException()) as KmmResult<Int>).fold(
                 onSuccess = { it * 42 },
                 onFailure = { 9 },
             ),
@@ -143,22 +143,22 @@ class KmmResultTest {
         assertEquals("KmmResult.success(null)", KmmResult.success<Int?>(null).toString())
         assertEquals(
             "KmmResult.failure(NullPointerException)",
-            KmmResult.failure<Int>(NullPointerException()).toString()
+            KmmResult.failure(NullPointerException()).toString()
         )
 
         assertEquals(
             "KmmResult.failure(NullPointerException())",
-            KmmResult.failure<Int>(NullPointerException("")).toString()
+            KmmResult.failure(NullPointerException("")).toString()
         )
 
         assertEquals(
             "KmmResult.failure(NullPointerException(null))",
-            KmmResult.failure<Int>(NullPointerException("null")).toString()
+            KmmResult.failure(NullPointerException("null")).toString()
         )
 
         assertEquals(
             "KmmResult.failure(NullPointerException(foo))",
-            KmmResult.failure<Int>(NullPointerException("foo")).toString()
+            KmmResult.failure(NullPointerException("foo")).toString()
         )
 
     }
@@ -264,6 +264,7 @@ class KmmResultTest {
     @Test
     fun testTypedFailure() {
         val x = Throwable("foobar")
+        @Suppress("DEPRECATION")
         assertEquals(KmmResult.failure(x), KmmResult.failure<Int>(x))
     }
 }


### PR DESCRIPTION
This also fixes the `@UnsafeVariance` use of `T`.